### PR TITLE
Set canvas version to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "http://github.com/mbostock/us-atlas.git"
   },
   "devDependencies": {
-    "canvas": "1",
+    "canvas": "1.0.4",
     "d3": "3",
     "shapefile": "0.1",
     "topojson": "1"


### PR DESCRIPTION
Canvas 1.1.0 seems to have a breaking change that causes the npm install to fail. Setting version to 1.0.4 for now.
