### PR TITLE
Make canvas & d3 deps optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "url": "http://github.com/mbostock/us-atlas.git"
   },
   "devDependencies": {
-    "canvas": "1",
-    "d3": "3",
     "shapefile": "0.1",
     "topojson": "1"
+  },
+  "optionalDependencies": {
+    "canvas": "1",
+    "d3": "3"
   }
 }


### PR DESCRIPTION
Canvas and D3 are only needed for png generation (while most people would use the repo for rolling out TopoJSON), and they're a trouble to install via npm if you only have command-line-tools instead of full Xcode on OS X. So I suggest moving them to optional dependencies.

> If a dependency can be used, but you would like npm to proceed if it cannot be found or fails to install, then you may put it in the optionalDependencies hash. This is a map of package name to version or url, just like the dependencies hash. The difference is that failure is tolerated.
