### PR TITLE
add gdal installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ This repository provides a convenient mechanism for generating TopoJSON files fr
 
 ## Installing via Homebrew
 
-Before you can run `make`, you’ll need to install Node.js. Here’s how to do that using [Homebrew](http://mxcl.github.com/homebrew/) on Mac OS X:
+Before you can make any TopoJSON files, you’ll need to install Node.js and gdal. Here’s how to do that using [Homebrew](http://mxcl.github.com/homebrew/) on Mac OS X:
 
 ```bash
-brew install node
+brew install node gdal
 ```
 
 Then, clone this repository and install its dependencies:


### PR DESCRIPTION
- Note that gdal is required as well as node. 
- don't recommend running `make` alone any more. (cf [#11](https://github.com/mbostock/us-atlas/issues/11))
