### PR TITLE
Use JSONStream instead of native JSON parser for big files

### DIFF
--- a/bin/geomerge
+++ b/bin/geomerge
@@ -2,36 +2,48 @@
 
 var fs = require("fs");
 
-var collection = JSON.parse(fs.readFileSync("/dev/stdin")),
-    spliceIndex = +process.argv[2],
-    targetGeometry = {type: "", coordinates: []};
+var JSONStream = require("JSONStream");
+var through2 = require("through2");
+var targetGeometry = {type: "", coordinates: []};
 
-collection.features.forEach(function(feature, i) {
-  if (i === spliceIndex) return;
-  var sourceGeometry = feature.geometry;
-  if (!sourceGeometry) return; // ignore null
+var startWritten = false;
 
-  var sourceType = sourceGeometry.type,
+process.stdin
+  .pipe(JSONStream.parse('features.*.geometry'))
+  .pipe(through2.obj(function (sourceGeometry, enc, callback) {
+    if (!sourceGeometry) return; // ignore null
+
+    var sourceType = sourceGeometry.type,
       targetType = /^Multi/.test(sourceType) ? sourceType : "Multi" + sourceType;
 
-  if (!targetGeometry.type) targetGeometry.type = targetType;
-  else if (targetGeometry.type !== targetType) throw new Error("incompatible types: " + targetType + " != " + targetGeometry.type);
+    if (!startWritten) {
+      process.stdout.write('{"type":"' + targetType + '","coordinates":');
+      startWritten = true;
+    }
 
-  switch (sourceType) {
-    case "MultiPolygon":
-    case "MultiLineString": {
-      sourceGeometry.coordinates.forEach(function(coordinates) { targetGeometry.coordinates.push(coordinates); });
-      break;
-    }
-    case "Polygon":
-    case "LineString": {
-      targetGeometry.coordinates.push(sourceGeometry.coordinates);
-      break;
-    }
-    default: {
-      throw new Error("unsupported type: " + g.type);
-    }
-  }
-});
+    if (!targetGeometry.type) targetGeometry.type = targetType;
+    else if (targetGeometry.type !== targetType) throw new Error("incompatible types: " + targetType + " != " + targetGeometry.type);
 
-console.log(JSON.stringify(targetGeometry));
+    switch (sourceType) {
+      case "MultiPolygon":
+      case "MultiLineString": {
+        sourceGeometry.coordinates.forEach(function(coordinates) { this.push(coordinates); }.bind(this));
+        callback();
+        break;
+      }
+      case "Polygon":
+      case "LineString": {
+        this.push(sourceGeometry.coordinates);
+        callback();
+        break;
+      }
+      default: {
+        callback(new Error("unsupported type: " + g.type));
+      }
+    }
+  }))
+  .pipe(JSONStream.stringify("[", ",", "]"))
+  .pipe(process.stdout)
+  .on("end", function () {
+    process.stdout.write("}");
+  });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "url": "http://github.com/mbostock/us-atlas.git"
   },
   "devDependencies": {
+    "JSONStream": "^1.2.1",
     "shapefile": "0.1",
+    "through2": "^2.0.1",
     "topojson": ">=1.6.2 <2"
   },
   "optionalDependencies": {


### PR DESCRIPTION
`./bin/geomerge < shp/us/zipcodes-unmerged.json > shp/us/zipcodes.json` was failing for me, because zipcodes-unmerged.json was 1.4GB big and v8 only allows strings to be 256MB big.

I rewrote bin/geomerge to use a streaming JSON parser instead of the native parser, which avoids loading the entire thing into memory. Doesn't solve the problem of the resulting JSON being 1.2GB big, but could solve other issues…

It removes the `spliceIndex` functionality, because we no longer have the index. I guess I can add a counter if that functionality is really wanted: should I add it back?
